### PR TITLE
Add encode capability to Samsung tool (with -e on the command line).

### DIFF
--- a/samsung/samsung.c
+++ b/samsung/samsung.c
@@ -27,11 +27,12 @@ int main(int argc, char** argv) {
 
   uint8_t *buf;
   size_t i ,buf_size;
+  int enc = (argc >= 4 && !strcmp(argv[3], "-e"));
 
   int ret = 0;
 
   if (argc < 3) {
-    printf("Usage: %s <input> <output>\n", argv[0]);
+    printf("Usage: %s <input> <output> [-e] \n", argv[0]);
     ret = -1;
     goto end;
   }
@@ -60,7 +61,7 @@ int main(int argc, char** argv) {
   }
 
   for (i = 0; i < buf_size; i++) {
-    buf[i] = decode(buf[i]);
+    buf[i] = enc ? encode(buf[i]) : decode(buf[i]);
   }
 
   if (!(op = fopen(argv[2], "wb"))) {


### PR DESCRIPTION
Since WDC uses a XOR cipher, no separate encode capability is needed there.
Simply re-decode an already decoded file to encode it back.
